### PR TITLE
ci: use semver for docker tags

### DIFF
--- a/.github/workflows/docker_build_push.yml
+++ b/.github/workflows/docker_build_push.yml
@@ -44,7 +44,8 @@ jobs:
             type=ref,event=branch
             type=ref,event=pr
             type=raw,value=test,enable={{is_default_branch}}
-            type=pep440,pattern={{version}}
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
 
       - name: Push to GitHub Container Registry
         uses: docker/build-push-action@v3


### PR DESCRIPTION
# Description

This PR replaces `pep440` with `semver` for docker tag generation.

## PR Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added or updated tests that comprehensively prove my change is effective or that my feature works
